### PR TITLE
Apt key fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The template to use for the Plex `Preferences.xml` file, and the path to which t
 
 ```
 plex_config_template: plex_preferences.xml.j2
-plex_config_file_path: /var/lib/plexmediaserver/Library/Application Support/Plex\ Media\ Server/Preferences.xml
+plex_config_file_path: "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Preferences.xml"
 ```
 
 ### Server IP address and Port

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
 
-plex_package: plexmediaserver
-plex_package_state: present
+plex_package: 'plexmediaserver'
+plex_package_state: 'present'
+plex_repo_hostname: 'downloads.plex.tv'
+plex_repo_apt_key_file: "/etc/apt/trusted.gpg.d/{{ plex_repo_hostname }}.gpg"
 
 plex_service_state: started
 plex_service_enabled: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,13 +3,13 @@
 plex_package: 'plexmediaserver'
 plex_package_state: 'present'
 plex_repo_hostname: 'downloads.plex.tv'
-plex_repo_apt_key_file: "/etc/apt/trusted.gpg.d/{{ plex_repo_hostname }}.gpg"
+plex_repo_apt_key_file: "/etc/apt/keyrings/{{ plex_repo_hostname }}.gpg"
 
 plex_service_state: started
 plex_service_enabled: true
 
 plex_config_template: plex_preferences.xml.j2
-plex_config_file_path: /var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Preferences.xml
+plex_config_file_path: "/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Preferences.xml"
 
 plex_server_accepted_eula: "1"
 plex_server_friendly_name: "XYZ"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure dependencies are installed.
-  apt:
+  ansible.builtin.apt:
     name:
       - apt-transport-https
       - gnupg2
@@ -13,21 +13,21 @@
     group: 'root'
     mode: '755'
 - name: Add Plex apt key.
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://{{ plex_repo_hostname }}/plex-keys/PlexSign.key
     keyring: "{{ plex_repo_apt_key_file }}"
     state: present
 - name: Add Plex apt repository.
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb [signed-by={{ plex_repo_apt_key_file }}] https://{{ plex_repo_hostname }}/repo/deb public main"
     state: present
     update_cache: true
 - name: Install Plex.
-  package:
+  ansilbe.builtin.package:
     name: "{{ plex_package }}"
     state: "{{ plex_package_state }}"
 - name: Ensure Plex is started and enabled at boot.
-  service:
+  ansible.builtin.service:
     name: plexmediaserver
     state: "{{ plex_service_state }}"
     enabled: "{{ plex_service_enabled }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,18 +12,18 @@
     owner: 'root'
     group: 'root'
     mode: '755'
-- name: Add Plex apt key.
+- name: "Add Plex APT signing key"
   ansible.builtin.apt_key:
-    url: https://{{ plex_repo_hostname }}/plex-keys/PlexSign.key
+    url: "https://{{ plex_repo_hostname }}/plex-keys/PlexSign.key"
     keyring: "{{ plex_repo_apt_key_file }}"
     state: present
-- name: Add Plex apt repository.
+- name: "Add Plex APT repository"
   ansible.builtin.apt_repository:
     repo: "deb [signed-by={{ plex_repo_apt_key_file }}] https://{{ plex_repo_hostname }}/repo/deb public main"
     state: present
     update_cache: true
-- name: Install Plex.
-  ansilbe.builtin.package:
+- name: "Install Plex via apt"
+  ansible.builtin.package:
     name: "{{ plex_package }}"
     state: "{{ plex_package_state }}"
 - name: Ensure Plex is started and enabled at boot.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,23 +5,27 @@
       - apt-transport-https
       - gnupg2
     state: present
-
+- name: "Creating APT keyring directory"
+  ansible.builtin.file:
+    path: '/etc/apt/keyrings'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '755'
 - name: Add Plex apt key.
   apt_key:
-    url: https://downloads.plex.tv/plex-keys/PlexSign.key
+    url: https://{{ plex_repo_hostname }}/plex-keys/PlexSign.key
+    keyring: "{{ plex_repo_apt_key_file }}"
     state: present
-
 - name: Add Plex apt repository.
   apt_repository:
-    repo: deb https://downloads.plex.tv/repo/deb public main
+    repo: "deb [signed-by={{ plex_repo_apt_key_file }}] https://{{ plex_repo_hostname }}/repo/deb public main"
     state: present
     update_cache: true
-
 - name: Install Plex.
   package:
     name: "{{ plex_package }}"
     state: "{{ plex_package_state }}"
-
 - name: Ensure Plex is started and enabled at boot.
   service:
     name: plexmediaserver


### PR DESCRIPTION
PR for new 

- Updated APT keyring policy
- ansible-lint cleanup
- Creates keyrings dir if not created
- Fixed bug in plex_config_file_path default